### PR TITLE
added javascript import for animation component

### DIFF
--- a/aframe-blueprint.cabal
+++ b/aframe-blueprint.cabal
@@ -1,5 +1,5 @@
 name:                aframe-blueprint
-version:             0.1.0.0
+version:             0.1.0.1
 -- synopsis:            
 -- description:         
 license:             BSD3

--- a/src/Text/AFrame/WebPage.hs
+++ b/src/Text/AFrame/WebPage.hs
@@ -7,8 +7,14 @@ import Text.AFrame
 import Paths_aframe_blueprint
 
 webPage :: [String] -> AFrame -> IO ()        
-webPage [fileOut] af = do
-    fileIn <- getDataFileName "static/index.html"
+webPage = webPageFromTemplate "static/index.html"
+
+webPageAnimated :: [String] -> AFrame -> IO ()
+webPageAnimated = webPageFromTemplate "static/animated.html"
+
+webPageFromTemplate :: String -> [String] -> AFrame -> IO ()
+webPageFromTemplate template [fileOut] af = do
+    fileIn <- getDataFileName template 
     file <- readFile fileIn
     writeFile fileOut $ injectAFrame af $ file
 

--- a/static/animated.html
+++ b/static/animated.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>A-Frame Scene</title>
+    <meta name="description" content="A-Frame Scene">
+
+    <script src="https://aframe.io/releases/0.3.0/aframe.min.js"></script>    
+    <script src="https://ku-fpg.github.io/js/aframe-frp.js"></script>    
+    <script src="https://rawgit.com/ngokevin/aframe-animation-component/master/dist/aframe-animation-component.min.js"></script>
+  </head>
+  <body>
+    <a-scene>
+    </a-scene>
+  </body>
+</html>


### PR DESCRIPTION
Backwards compatibility is preserved with this change.

This extra script could have just been added to index.html,
but for projects that didn't use the animation component, that would
bloat the output file unnecessarily.

The included script should probably be moved to a ku-fpg location for
safety, but I don't know exactly where to put that or how to do so.